### PR TITLE
Remove drop shadow from text-extra-style

### DIFF
--- a/pizza.css
+++ b/pizza.css
@@ -10,7 +10,6 @@ body,html{
 
 .text-extra-style {
 	color: #44aedb;
-	text-shadow: 2px 2px 2px #ddd
 }
 
 * {


### PR DESCRIPTION
The drop shadow on the text does not really fit in with the general, material theme of the site, so I propose we remove it.