### PR TITLE
Fix/increased nick length

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for EatIT in production
-FROM debian:jessie AS buildStage
+FROM debian:bookworm AS buildStage
 MAINTAINER digIT <digit@chalmers.it>
 
 ENV METEOR_VERSION 1.6.1

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for EatIT in development
-FROM debian
+FROM debian:bookworm
 MAINTAINER digIT <digit@chalmers.it>
 
 ENV METEOR_VERSION 1.6.1

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for EatIT in development
-FROM debian:jessie
+FROM debian
 MAINTAINER digIT <digit@chalmers.it>
 
 ENV METEOR_VERSION 1.6.1

--- a/imports/use-cases/main/screens/order/views/order-box/OrderBox.view.jsx
+++ b/imports/use-cases/main/screens/order/views/order-box/OrderBox.view.jsx
@@ -15,7 +15,7 @@ import {
 import * as yup from "yup";
 
 const MAX_LENGTH_PIZZA = 150;
-const MAX_LENGTH_NICK = 30;
+const MAX_LENGTH_NICK = 100;
 
 class OrderBox extends Component {
     constructor(props) {


### PR DESCRIPTION
increased the nick length from 30 to 100 so people can comfortably input 'name "nick" lastname' for multiple people in the same order in the case of splitting meals like pizzas in two.